### PR TITLE
Add a benchmark for jsoniter-scala

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ import org.gradle.internal.os.OperatingSystem
 
 plugins {
     id 'java'
+    id 'scala'
     id 'me.champeau.jmh' version '0.7.1'
 }
 
@@ -27,6 +28,8 @@ dependencies {
     jmhImplementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.15.2'
     jmhImplementation group: 'com.alibaba.fastjson2', name: 'fastjson2', version: '2.0.35'
     jmhImplementation group: 'com.jsoniter', name: 'jsoniter', version: '0.9.23'
+    jmhImplementation group: 'com.github.plokhotnyuk.jsoniter-scala', name: 'jsoniter-scala-core_2.13', version: '2.23.2'
+    compileOnly group: 'com.github.plokhotnyuk.jsoniter-scala', name: 'jsoniter-scala-macros_2.13', version: '2.23.2'
 
     testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.24.2'
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: junitVersion
@@ -49,6 +52,10 @@ tasks.withType(JmhBytecodeGeneratorTask).configureEach {
 tasks.withType(JavaCompile).configureEach {
     options.compilerArgs.add("--add-modules=jdk.incubator.vector")
 }
+
+tasks.compileJmhScala.classpath = sourceSets.main.compileClasspath
+
+tasks.compileJmhJava.classpath += files(sourceSets.jmh.scala.classesDirectory)
 
 compileTestJava {
     options.compilerArgs += [

--- a/src/jmh/java/com/github/piotrrzysko/simdjson/ParseAndSelectBenchmark.java
+++ b/src/jmh/java/com/github/piotrrzysko/simdjson/ParseAndSelectBenchmark.java
@@ -4,6 +4,8 @@ import com.alibaba.fastjson2.JSON;
 import com.alibaba.fastjson2.JSONObject;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.plokhotnyuk.jsoniter_scala.core.ReaderConfig$;
+import com.github.plokhotnyuk.jsoniter_scala.core.package$;
 import com.jsoniter.JsonIterator;
 import com.jsoniter.any.Any;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -41,6 +43,19 @@ public class ParseAndSelectBenchmark {
             buffer = is.readAllBytes();
             bufferPadded = padded(buffer);
         }
+    }
+
+    @Benchmark
+    public int countUniqueUsersWithDefaultProfile_jsoniter_scala() throws IOException {
+        Twitter twitter = package$.MODULE$.readFromArray(buffer, ReaderConfig$.MODULE$, Twitter$.MODULE$.codec());
+        Set<String> defaultUsers = new HashSet<>();
+        for (Status tweet: twitter.statuses()) {
+            User user = tweet.user();
+            if (user.default_profile()) {
+                defaultUsers.add(user.screen_name());
+            }
+        }
+        return defaultUsers.size();
     }
 
     @Benchmark

--- a/src/jmh/scala/com/github/piotrrzysko/simdjson/Twitter.scala
+++ b/src/jmh/scala/com/github/piotrrzysko/simdjson/Twitter.scala
@@ -1,0 +1,14 @@
+package com.github.piotrrzysko.simdjson
+
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
+import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
+
+case class User(default_profile: Boolean, screen_name: String)
+
+case class Status(user: User)
+
+case class Twitter(statuses: Array[Status])
+
+object Twitter {
+  val codec: JsonValueCodec[Twitter] = JsonCodecMaker.make
+}


### PR DESCRIPTION
@piotrrzysko Thanks for porting of simdjson to Java!

This PR adds `ParseAndSelectBenchmark` for jsoniter-scala.

Results are quite competitive on my laptop (Intel® Core™ i7-11800H CPU @ 2.3GHz (max 4.6GHz), RAM 64Gb DDR4-3200, Ubuntu 23.04 (Linux 6.2) using  OpenJDK 64-Bit Server VM Temurin-20.0.1+9:

```
Benchmark                                                                   Mode  Cnt     Score    Error  Units
ParseAndSelectBenchmark.countUniqueUsersWithDefaultProfile_fastjson        thrpt    5   916.814 ± 24.732  ops/s
ParseAndSelectBenchmark.countUniqueUsersWithDefaultProfile_jackson         thrpt    5   784.450 ±  1.973  ops/s
ParseAndSelectBenchmark.countUniqueUsersWithDefaultProfile_jsoniter        thrpt    5   602.781 ± 10.898  ops/s
ParseAndSelectBenchmark.countUniqueUsersWithDefaultProfile_jsoniter_scala  thrpt    5  2393.011 ± 28.473  ops/s
ParseAndSelectBenchmark.countUniqueUsersWithDefaultProfile_simdjson        thrpt    5  2295.253 ± 64.139  ops/s
ParseAndSelectBenchmark.countUniqueUsersWithDefaultProfile_simdjsonPadded  thrpt    5  2460.363 ± 42.452  ops/s
```

While it doesn't full validation of skipped values according to JSON spec, but it does just enough minimal validation to allow safe skipping of not needed keys and values.