### PR TITLE
Specify in Gradle the minimum supported Java version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,13 @@ repositories {
 }
 
 java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(18)
+    // It seems that specifying the minimum supported Java version while allowing the use of newer
+    // ones isn't possible in Gradle. To test the library against multiple Java versions, the
+    // workaround proposed in https://github.com/gradle/gradle/issues/16256 has been applied:
+    if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_18)) {
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(18)
+        }
     }
     withJavadocJar()
     withSourcesJar()

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,1 @@
-plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
-}
-
 rootProject.name = 'simdjson-java'


### PR DESCRIPTION
#29 introduced a set of GitHub actions testing the library against multiple Java versions. It turns out that this doesn't work as expected. The version specified in build.gradle is automatically downloaded when not available on a machine, thereby the JAVA_HOME environment variable is ignored. As a result, the Java versions provided by the GitHub actions aren't used. This PR should fix this issue.