### PR TITLE
Update benchmark dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,12 +43,12 @@ java {
 
 ext {
     junitVersion = '5.9.1'
-    jsoniterScalaVersion = '2.23.2'
+    jsoniterScalaVersion = '2.24.4'
 }
 
 dependencies {
-    jmhImplementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.15.2'
-    jmhImplementation group: 'com.alibaba.fastjson2', name: 'fastjson2', version: '2.0.35'
+    jmhImplementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.16.0'
+    jmhImplementation group: 'com.alibaba.fastjson2', name: 'fastjson2', version: '2.0.42'
     jmhImplementation group: 'com.jsoniter', name: 'jsoniter', version: '0.9.23'
     jmhImplementation group: 'com.github.plokhotnyuk.jsoniter-scala', name: 'jsoniter-scala-core_2.13', version: jsoniterScalaVersion
     compileOnly group: 'com.github.plokhotnyuk.jsoniter-scala', name: 'jsoniter-scala-macros_2.13', version: jsoniterScalaVersion


### PR DESCRIPTION
Results on Intel® Core™ i7-11800H CPU @ 2.3GHz (max 4.6GHz), RAM 64Gb DDR4-3200, Ubuntu 23.10 (Linux 6.6.1) with JDK 21 (Java HotSpot(TM) 64-Bit Server VM, 21+35-LTS-2513):
```txt
Benchmark                                                                   Mode  Cnt     Score     Error  Units
ParseAndSelectBenchmark.countUniqueUsersWithDefaultProfile_fastjson        thrpt    5   914.874 ±  42.911  ops/s
ParseAndSelectBenchmark.countUniqueUsersWithDefaultProfile_jackson         thrpt    5   816.881 ±  14.097  ops/s
ParseAndSelectBenchmark.countUniqueUsersWithDefaultProfile_jsoniter        thrpt    5   527.052 ±  66.106  ops/s
ParseAndSelectBenchmark.countUniqueUsersWithDefaultProfile_jsoniter_scala  thrpt    5  2476.427 ±  42.218  ops/s
ParseAndSelectBenchmark.countUniqueUsersWithDefaultProfile_simdjson        thrpt    5  2382.208 ±  16.461  ops/s
ParseAndSelectBenchmark.countUniqueUsersWithDefaultProfile_simdjsonPadded  thrpt    5  2472.811 ± 111.562  ops/s
```