### PR TITLE
Reduce size of buffer, stringBuffer and tape.

### DIFF
--- a/src/main/java/org/simdjson/SimdJsonParser.java
+++ b/src/main/java/org/simdjson/SimdJsonParser.java
@@ -11,7 +11,7 @@ public class SimdJsonParser {
     private final StructuralIndexer indexer;
     private final BitIndexes bitIndexes;
     private final JsonIterator jsonIterator;
-    private final byte[] paddedBuffer;
+    private final int capacity;
 
     public SimdJsonParser() {
         this(DEFAULT_CAPACITY, DEFAULT_MAX_DEPTH);
@@ -20,7 +20,7 @@ public class SimdJsonParser {
     public SimdJsonParser(int capacity, int maxDepth) {
         bitIndexes = new BitIndexes(capacity);
         jsonIterator = new JsonIterator(bitIndexes, capacity, maxDepth, PADDING);
-        paddedBuffer = new byte[capacity];
+        this.capacity = capacity;
         reader = new BlockReader(STEP_SIZE);
         indexer = new StructuralIndexer(bitIndexes);
     }
@@ -34,7 +34,8 @@ public class SimdJsonParser {
     }
 
     private byte[] padIfNeeded(byte[] buffer, int len) {
-        if (buffer.length - len < PADDING) {
+        if (buffer.length - len < PADDING && len < capacity) {
+            byte[] paddedBuffer = new byte[len + PADDING];
             System.arraycopy(buffer, 0, paddedBuffer, 0, len);
             return paddedBuffer;
         }

--- a/src/main/java/org/simdjson/StringParser.java
+++ b/src/main/java/org/simdjson/StringParser.java
@@ -26,6 +26,10 @@ class StringParser {
         this.stringBuffer = stringBuffer;
     }
 
+    int getStringBufferIdx() {
+        return stringBufferIdx;
+    }
+
     void parseString(byte[] buffer, int idx) {
         tape.append(stringBufferIdx, STRING);
         int src = idx + 1;

--- a/src/main/java/org/simdjson/Tape.java
+++ b/src/main/java/org/simdjson/Tape.java
@@ -25,6 +25,12 @@ class Tape {
         tape = new long[capacity];
     }
 
+    Tape(Tape other) {
+        this.tape = new long[other.tapeIdx];
+        System.arraycopy(other.tape, 0, this.tape, 0, other.tapeIdx);
+        this.tapeIdx = other.tapeIdx;
+    }
+
     void append(long val, char type) {
         tape[tapeIdx] = val | (((long) type) << 56);
         tapeIdx++;

--- a/src/main/java/org/simdjson/TapeBuilder.java
+++ b/src/main/java/org/simdjson/TapeBuilder.java
@@ -206,7 +206,13 @@ class TapeBuilder {
     }
 
     JsonValue createJsonValue(byte[] buffer) {
-        return new JsonValue(tape, 1, stringBuffer, buffer);
+        Tape newTape = new Tape(tape);
+
+        int stringBufferLen = stringParser.getStringBufferIdx();
+        byte[] newStringBuffer = new byte[stringBufferLen];
+        System.arraycopy(stringBuffer, 0, newStringBuffer, 0, stringBufferLen);
+
+        return new JsonValue(newTape, 1, newStringBuffer, buffer);
     }
 
     private static class OpenContainer {


### PR DESCRIPTION
In class JsonValue, the default size of buffer and stringBuffer, as well as long[] tape in class Tape, is 34M.
But in practice it's not necessary.
This patch reduce the size of them from 34M to its actual size.