### PR TITLE
handle null values while parsing double and float

### DIFF
--- a/src/main/java/org/simdjson/NumberParser.java
+++ b/src/main/java/org/simdjson/NumberParser.java
@@ -226,6 +226,7 @@ class NumberParser {
         currentIdx = digitsParsingResult.currentIdx();
         int digitCount = currentIdx - digitsStartIdx;
         if (digitCount == 0) {
+            if (checkIfNull(buffer, len, offset)) return Float.NaN;
             throw new JsonParsingException("Invalid number. Minus has to be followed by a digit.");
         }
         if ('0' == buffer[digitsStartIdx] && digitCount > 1) {
@@ -273,6 +274,7 @@ class NumberParser {
         currentIdx = digitsParsingResult.currentIdx();
         int digitCount = currentIdx - digitsStartIdx;
         if (digitCount == 0) {
+            if (checkIfNull(buffer, len, offset)) return Double.NaN;
             throw new JsonParsingException("Invalid number. Minus has to be followed by a digit.");
         }
         if ('0' == buffer[digitsStartIdx] && digitCount > 1) {
@@ -360,4 +362,11 @@ class NumberParser {
             return currentIdx;
         }
     }
+
+    private boolean checkIfNull(byte[] buffer, int len, int offset) {
+        boolean statsWithN = buffer[offset] == 'n' || buffer[offset] == 'N';
+        boolean endsWithL = buffer[offset + 3] == 'l' || buffer[offset + 3] == 'L';
+        return statsWithN && endsWithL;
+    }
+
 }


### PR DESCRIPTION
When you try to parse JSON that has field with type (for ex.) double and value of that field is null, then it throws and exception.
That PR will allow such value for Double and Float, since they have value NaN that fits for that purpose.