### PR TITLE
reset bitindex twice

### DIFF
--- a/src/main/java/org/simdjson/SimdJsonParser.java
+++ b/src/main/java/org/simdjson/SimdJsonParser.java
@@ -48,7 +48,6 @@ public class SimdJsonParser {
     }
 
     private void reset() {
-        bitIndexes.reset();
         jsonIterator.reset();
     }
 


### PR DESCRIPTION
hello, piotrrzysko.
In class of SimdJsonParser, bitIndexes will be reset twice each time json is parsed.
once in the function of reset, another in the function of stage1, for bitIndexes variable of SimdJsonParser equal to bitIndexes variable of StructuralIndexer. so maybe we can reset once.
<img width="348" alt="image" src="https://github.com/user-attachments/assets/9e01e77c-62b0-4f1a-b5c7-7b0ffd4f9ed4">
<img width="924" alt="image" src="https://github.com/user-attachments/assets/34b860c7-84a3-45f2-8373-94c32e3860d9">

