### PR TITLE
Optimize Utf8Validator with constant input Vector.slice API

### DIFF
--- a/src/main/java/org/simdjson/Utf8Validator.java
+++ b/src/main/java/org/simdjson/Utf8Validator.java
@@ -11,8 +11,8 @@ import static jdk.incubator.vector.VectorOperators.EQ;
 import static jdk.incubator.vector.VectorOperators.LSHL;
 import static jdk.incubator.vector.VectorOperators.LSHR;
 import static jdk.incubator.vector.VectorOperators.NE;
-import static jdk.incubator.vector.VectorOperators.UNSIGNED_GE;
-import static jdk.incubator.vector.VectorOperators.UNSIGNED_GT;
+import static jdk.incubator.vector.VectorOperators.UGE;
+import static jdk.incubator.vector.VectorOperators.UGT;
 import static jdk.incubator.vector.VectorShuffle.iota;
 import static org.simdjson.VectorUtils.BYTE_SPECIES;
 import static org.simdjson.VectorUtils.INT_SPECIES;
@@ -40,8 +40,6 @@ class Utf8Validator {
     private static final byte TWO_CONTINUATIONS = (byte) (1 << 7);
     private static final byte MAX_2_LEADING_BYTE = (byte) 0b110_11111;
     private static final byte MAX_3_LEADING_BYTE = (byte) 0b1110_1111;
-    private static final int TWO_BYTES_SIZE = Byte.SIZE * 2;
-    private static final int THREE_BYTES_SIZE = Byte.SIZE * 3;
     private static final ByteVector BYTE_1_HIGH_LOOKUP = createByte1HighLookup();
     private static final ByteVector BYTE_1_LOW_LOOKUP = createByte1LowLookup();
     private static final ByteVector BYTE_2_HIGH_LOOKUP = createByte2HighLookup();
@@ -52,12 +50,12 @@ class Utf8Validator {
     private static final int STEP_SIZE = BYTE_SPECIES.vectorByteSize();
 
     static void validate(byte[] buffer, int length) {
-        long previousIncomplete = 0;
-        long errors = 0;
-        int previousFourUtf8Bytes = 0;
-
-        int loopBound = BYTE_SPECIES.loopBound(length);
         int offset = 0;
+        long errors = 0;
+        long previousIncomplete = 0;
+        int loopBound = BYTE_SPECIES.loopBound(length);
+        ByteVector previousChunk = ByteVector.broadcast(BYTE_SPECIES, 0);
+
         for (; offset < loopBound; offset += STEP_SIZE) {
             ByteVector chunk = ByteVector.fromArray(BYTE_SPECIES, buffer, offset);
             IntVector chunkAsInts = chunk.reinterpretAsInts();
@@ -65,19 +63,10 @@ class Utf8Validator {
             if (chunk.and(ALL_ASCII_MASK).compare(EQ, 0).allTrue()) {
                 errors |= previousIncomplete;
             } else {
-                previousIncomplete = chunk.compare(UNSIGNED_GE, INCOMPLETE_CHECK).toLong();
-                // Shift the input forward by four bytes to make space for the previous four bytes.
-                // The previous three bytes are required for validation, pulling in the last integer
-                // will give the previous four bytes. The switch to integer vectors is to allow for
-                // integer shifting instead of the more expensive shuffle / slice operations.
-                IntVector chunkWithPreviousFourBytes = chunkAsInts
-                        .rearrange(FOUR_BYTES_FORWARD_SHIFT)
-                        .withLane(0, previousFourUtf8Bytes);
-                // Shift the current input forward by one byte to include one byte from the previous chunk.
-                ByteVector previousOneByte = chunkAsInts
-                        .lanewise(LSHL, Byte.SIZE)
-                        .or(chunkWithPreviousFourBytes.lanewise(LSHR, THREE_BYTES_SIZE))
-                        .reinterpretAsBytes();
+                previousIncomplete = chunk.compare(UGE, INCOMPLETE_CHECK).toLong();
+                // Pull in last byte from previous chunk.
+                ByteVector previousOneByte = previousChunk.slice(BYTE_SPECIES.length() - 1, chunk);
+
                 ByteVector byte2HighNibbles = chunkAsInts.lanewise(LSHR, 4)
                         .reinterpretAsBytes()
                         .and(LOW_NIBBLE_MASK);
@@ -85,31 +74,29 @@ class Utf8Validator {
                         .lanewise(LSHR, 4)
                         .reinterpretAsBytes()
                         .and(LOW_NIBBLE_MASK);
+
                 ByteVector byte1LowNibbles = previousOneByte.and(LOW_NIBBLE_MASK);
                 ByteVector byte1HighState = byte1HighNibbles.selectFrom(BYTE_1_HIGH_LOOKUP);
                 ByteVector byte1LowState = byte1LowNibbles.selectFrom(BYTE_1_LOW_LOOKUP);
                 ByteVector byte2HighState = byte2HighNibbles.selectFrom(BYTE_2_HIGH_LOOKUP);
                 ByteVector firstCheck = byte1HighState.and(byte1LowState).and(byte2HighState);
+
                 // All remaining checks are for invalid 3 and 4-byte sequences, which either have too many
                 // continuation bytes or not enough.
-                ByteVector previousTwoBytes = chunkAsInts
-                        .lanewise(LSHL, TWO_BYTES_SIZE)
-                        .or(chunkWithPreviousFourBytes.lanewise(LSHR, TWO_BYTES_SIZE))
-                        .reinterpretAsBytes();
+                ByteVector previousTwoBytes = previousChunk.slice(BYTE_SPECIES.length() - 2, chunk);
+
                 // The minimum leading byte of 3-byte sequences is always greater than the maximum leading byte of 2-byte sequences.
-                VectorMask<Byte> is3ByteLead = previousTwoBytes.compare(UNSIGNED_GT, MAX_2_LEADING_BYTE);
-                ByteVector previousThreeBytes = chunkAsInts
-                        .lanewise(LSHL, THREE_BYTES_SIZE)
-                        .or(chunkWithPreviousFourBytes.lanewise(LSHR, Byte.SIZE))
-                        .reinterpretAsBytes();
+                VectorMask<Byte> is3ByteLead = previousTwoBytes.compare(UGT, MAX_2_LEADING_BYTE);
+                ByteVector previousThreeBytes = previousChunk.slice(BYTE_SPECIES.length() - 3, chunk);
+
                 // The minimum leading byte of 4-byte sequences is always greater than the maximum leading byte of 3-byte sequences.
-                VectorMask<Byte> is4ByteLead = previousThreeBytes.compare(UNSIGNED_GT, MAX_3_LEADING_BYTE);
+                VectorMask<Byte> is4ByteLead = previousThreeBytes.compare(UGT, MAX_3_LEADING_BYTE);
                 // The firstCheck vector contains 0x80 values on continuation byte indexes.
                 // The leading bytes of 3 and 4-byte sequences should match up with these indexes and zero them out.
                 ByteVector secondCheck = firstCheck.add((byte) 0x80, is3ByteLead.or(is4ByteLead));
                 errors |= secondCheck.compare(NE, 0).toLong();
             }
-            previousFourUtf8Bytes = chunkAsInts.lane(INT_SPECIES.length() - 1);
+            previousChunk = chunk;
         }
 
         // If the input file doesn't align with the vector width, pad the missing bytes with zeros.
@@ -117,19 +104,9 @@ class Utf8Validator {
         ByteVector chunk = ByteVector.fromArray(BYTE_SPECIES, buffer, offset, remainingBytes);
         if (!chunk.and(ALL_ASCII_MASK).compare(EQ, 0).allTrue()) {
             IntVector chunkAsInts = chunk.reinterpretAsInts();
-            previousIncomplete = chunk.compare(UNSIGNED_GE, INCOMPLETE_CHECK).toLong();
-            // Shift the input forward by four bytes to make space for the previous four bytes.
-            // The previous three bytes are required for validation, pulling in the last integer
-            // will give the previous four bytes. The switch to integer vectors is to allow for
-            // integer shifting instead of the more expensive shuffle / slice operations.
-            IntVector chunkWithPreviousFourBytes = chunkAsInts
-                    .rearrange(FOUR_BYTES_FORWARD_SHIFT)
-                    .withLane(0, previousFourUtf8Bytes);
-            // Shift the current input forward by one byte to include one byte from the previous chunk.
-            ByteVector previousOneByte = chunkAsInts
-                    .lanewise(LSHL, Byte.SIZE)
-                    .or(chunkWithPreviousFourBytes.lanewise(LSHR, THREE_BYTES_SIZE))
-                    .reinterpretAsBytes();
+            previousIncomplete = chunk.compare(UGE, INCOMPLETE_CHECK).toLong();
+            // Pull in last byte from previous chunk.
+            ByteVector previousOneByte = previousChunk.slice(BYTE_SPECIES.length() - 1, chunk);
             ByteVector byte2HighNibbles = chunkAsInts.lanewise(LSHR, 4)
                     .reinterpretAsBytes()
                     .and(LOW_NIBBLE_MASK);
@@ -144,18 +121,14 @@ class Utf8Validator {
             ByteVector firstCheck = byte1HighState.and(byte1LowState).and(byte2HighState);
             // All remaining checks are for invalid 3 and 4-byte sequences, which either have too many
             // continuation bytes or not enough.
-            ByteVector previousTwoBytes = chunkAsInts
-                    .lanewise(LSHL, TWO_BYTES_SIZE)
-                    .or(chunkWithPreviousFourBytes.lanewise(LSHR, TWO_BYTES_SIZE))
-                    .reinterpretAsBytes();
+            // Pull in last two bytes from previous chunk.
+            ByteVector previousTwoBytes = previousChunk.slice(BYTE_SPECIES.length() - 2, chunk);
             // The minimum leading byte of 3-byte sequences is always greater than the maximum leading byte of 2-byte sequences.
-            VectorMask<Byte> is3ByteLead = previousTwoBytes.compare(UNSIGNED_GT, MAX_2_LEADING_BYTE);
-            ByteVector previousThreeBytes = chunkAsInts
-                    .lanewise(LSHL, THREE_BYTES_SIZE)
-                    .or(chunkWithPreviousFourBytes.lanewise(LSHR, Byte.SIZE))
-                    .reinterpretAsBytes();
+            VectorMask<Byte> is3ByteLead = previousTwoBytes.compare(UGT, MAX_2_LEADING_BYTE);
+            ByteVector previousThreeBytes = previousChunk.slice(BYTE_SPECIES.length() - 3, chunk);
             // The minimum leading byte of 4-byte sequences is always greater than the maximum leading byte of 3-byte sequences.
-            VectorMask<Byte> is4ByteLead = previousThreeBytes.compare(UNSIGNED_GT, MAX_3_LEADING_BYTE);
+            // Pull in last three bytes from previous chunk.
+            VectorMask<Byte> is4ByteLead = previousThreeBytes.compare(UGT, MAX_3_LEADING_BYTE);
             // The firstCheck vector contains 0x80 values on continuation byte indexes.
             // The leading bytes of 3 and 4-byte sequences should match up with these indexes and zero them out.
             ByteVector secondCheck = firstCheck.add((byte) 0x80, is3ByteLead.or(is4ByteLead));


### PR DESCRIPTION
Patch replaces existing bulky handling for pulling in last, second last and third last byte of pervious byte vector chunk in Utf8Validator with optimized constant input Vector.slice API.

Following are the results of the performance analysis of Utf8ValidatorBenchmark on AMD Ryzen 7 7840HS 8C 16T AVX512 system.

```
Baseline: jdk-24.0.2
Benchmark                                (fileName)   Mode  Cnt      Score   Error  Units
Utf8ValidatorBenchmark.utf8Validator  /twitter.json  thrpt    2  62117.351          ops/s

Withopt: jdk-24.0.2
Benchmark                                (fileName)   Mode  Cnt      Score   Error  Units
Utf8ValidatorBenchmark.utf8Validator  /twitter.json  thrpt    2  80763.046          ops/s

Root cause of gain: Exitance of VPERMB instruction on AVX512_VBMI targets
targets.
   1.33%  ││ │  0x0000735a1422bde2:   vpermb %zmm0,%zmm3,%zmm1
   5.41%  ││ │  0x0000735a1422bde8:   vpermb %zmm11,%zmm3,%zmm2
   1.54%  ││ │  0x0000735a1422bdee:   vpblendmb %zmm1,%zmm2,%zmm1{%k3}

Baseline: jdk-26
Benchmark                                     (fileName)   Mode  Cnt      Score   Error  Units
Utf8ValidatorBenchmark.utf8Validator       /twitter.json  thrpt    2  59075.477          ops/s

Withopt: jdk-26 (without ALIGNR)
Benchmark                                     (fileName)   Mode  Cnt      Score   Error  Units
Utf8ValidatorBenchmark.utf8Validator       /twitter.json  thrpt    2  81333.082          ops/s

Withopt: jdk mainline (with ALIGNR)
Benchmark                                     (fileName)   Mode  Cnt      Score   Error  Units
Utf8ValidatorBenchmark.utf8Validator       /twitter.json  thrpt    2  85728.800          ops/s
Utf8ValidatorBenchmark.utf8Validator:·asm  /twitter.json  thrpt             NaN            --- 
```

Analysis:
Utf8Validator with slice API is performant on AVX512 targets even without ALIGNR based instruction sequence.
But, on AVX2/Intel E-core targets only ALIGNR based slice optimization part of JDK mainline PR[1] will be performant.

On AMD targets, where both client and servers support AVX512 ISA, slice based Utf8Validator will always
be performant even with stock JDK-24.0.2.

While on Intel targets we need to wait till integration of PR[1] and also gradle compatibility with jdk-25+,
JDK-8290322 improved the byte vector rearrange on AVX2/E-core targets but its performance does not
match up to direct VPERMB instruction.  

PS: Patch depends on integration of eixsint simd-json PR[2]

[1] https://github.com/openjdk/jdk/pull/24104
[2] https://github.com/simdjson/simdjson-java/pull/67