### PR TITLE
1 line fix + benchmark: stop resetting class cache for each document

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ java {
 
 ext {
     junitVersion = '5.12.0'
-    jsoniterScalaVersion = '2.33.2'
+    jsoniterScalaVersion = '2.38.9'
 }
 
 dependencies {

--- a/src/jmh/java/org/simdjson/SchemaBasedParseBenchmark.java
+++ b/src/jmh/java/org/simdjson/SchemaBasedParseBenchmark.java
@@ -1,0 +1,202 @@
+package org.simdjson;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.SingleShotTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class SchemaBasedParseBenchmark {
+    private final SimdJsonParser simdJsonParser = new SimdJsonParser();
+    private final ObjectMapper objectMapper = new ObjectMapper()
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    private byte[][] buffers;
+
+    @Setup(Level.Trial)
+    public void setup() throws IOException {
+        try (InputStream is = ParseBenchmark.class.getResourceAsStream("/twitter.json")) {
+            byte[] allBytes = is.readAllBytes();
+            // Reserialize into individual JSON byte arrays to simulate the use case of
+            // deserializing a large number of small (1-2 KB) JSON messages.
+            JsonNode statusesWrapper = objectMapper.readTree(allBytes);
+            JsonNode statusesArray = statusesWrapper.get("statuses");
+
+            buffers = new byte[statusesArray.size()][];
+
+            for (int i = 0; i < statusesArray.size(); i++) {
+                JsonNode status = statusesArray.get(i);
+                byte[] buffer = objectMapper.writeValueAsBytes(status);
+                buffers[i] = buffer;
+            }
+        }
+        System.out.println("VectorSpecies = " + VectorUtils.BYTE_SPECIES);
+        System.out.println("Number of messages = " + buffers.length);
+    }
+
+    @Benchmark
+    public void simdjson(Blackhole blackhole) {
+        for (byte[] buffer : buffers) {
+            blackhole.consume(simdJsonParser.parse(buffer, buffer.length, Status.class));
+        }
+    }
+
+    @Benchmark
+    public void jackson(Blackhole blackhole) throws IOException {
+        for (byte[] buffer : buffers) {
+            blackhole.consume(objectMapper.readValue(buffer, Status.class));
+        }
+    }
+
+    // objects in twitter.json
+    public record Status(
+        Metadata metadata,
+        String created_at,
+        long id,
+        String id_str,
+        String text,
+        String source,
+        boolean truncated,
+        Long in_reply_to_status_id,
+        String in_reply_to_status_id_str,
+        Long in_reply_to_user_id,
+        String in_reply_to_user_id_str,
+        String in_reply_to_screen_name,
+        User user,
+        Object geo,
+        Object coordinates,
+        Object place,
+        Object contributors,
+        // cannot handle recursion
+        // Status retweeted_status,
+        long retweet_count,
+        long favorite_count,
+        Entities entities,
+        boolean favorited,
+        boolean retweeted,
+        Boolean possibly_sensitive,
+        String lang
+    ) {
+        public record Metadata(
+            String result_type,
+            String iso_language_code
+        ) {}
+
+        public record User(
+            long id,
+            String id_str,
+            String name,
+            String screen_name,
+            String location,
+            String description,
+            String url,
+            UserEntities entities,
+            // cannot parse Java keyword
+            // boolean protected,
+            long followers_count,
+            long friends_count,
+            long listed_count,
+            String created_at,
+            long favourites_count,
+            Integer utc_offset,
+            String time_zone,
+            boolean geo_enabled,
+            boolean verified,
+            long statuses_count,
+            String lang,
+            boolean contributors_enabled,
+            boolean is_translator,
+            boolean is_translation_enabled,
+            String profile_background_color,
+            String profile_background_image_url,
+            String profile_background_image_url_https,
+            boolean profile_background_tile,
+            String profile_image_url,
+            String profile_image_url_https,
+            String profile_banner_url,
+            String profile_link_color,
+            String profile_sidebar_border_color,
+            String profile_sidebar_fill_color,
+            String profile_text_color,
+            boolean profile_use_background_image,
+            boolean default_profile,
+            boolean default_profile_image,
+            boolean following,
+            boolean follow_request_sent,
+            boolean notifications
+        ) {}
+
+        public record UserEntities(
+            UrlList url,
+            UrlList description
+        ) {}
+
+        public record Entities(
+            List<Hashtag> hashtags,
+            List<Object> symbols,
+            List<UrlEntity> urls,
+            List<UserMention> user_mentions,
+            List<MediaEntity> media
+        ) {}
+
+        public record UrlList(
+            List<UrlEntity> urls
+        ) {}
+
+        public record Hashtag(
+            String text,
+            List<Integer> indices
+        ) {}
+
+        public record UrlEntity(
+            String url,
+            String expanded_url,
+            String display_url,
+            List<Integer> indices
+        ) {}
+
+        public record UserMention(
+            String screen_name,
+            String name,
+            long id,
+            String id_str,
+            List<Integer> indices
+        ) {}
+
+        public record MediaEntity(
+            long id,
+            String id_str,
+            List<Integer> indices,
+            String media_url,
+            String media_url_https,
+            String url,
+            String display_url,
+            String expanded_url,
+            String type,
+            MediaSizes sizes,
+            Long source_status_id,
+            String source_status_id_str
+        ) {}
+
+        public record MediaSizes(
+            MediaSize medium,
+            MediaSize small,
+            MediaSize thumb,
+            MediaSize large
+        ) {}
+
+        public record MediaSize(
+            int w,
+            int h,
+            String resize
+        ) {}
+    }
+}

--- a/src/main/java/org/simdjson/SchemaBasedJsonIterator.java
+++ b/src/main/java/org/simdjson/SchemaBasedJsonIterator.java
@@ -28,7 +28,6 @@ class SchemaBasedJsonIterator {
     @SuppressWarnings("unchecked")
     <T> T walkDocument(byte[] padded, int len, Class<T> expectedType) {
         jsonIterator.init(padded, len);
-        // classResolver.reset();
 
         ResolvedClass resolvedExpectedClass = classResolver.resolveClass(expectedType);
         return switch (resolvedExpectedClass.getClassCategory()) {

--- a/src/main/java/org/simdjson/SchemaBasedJsonIterator.java
+++ b/src/main/java/org/simdjson/SchemaBasedJsonIterator.java
@@ -28,7 +28,7 @@ class SchemaBasedJsonIterator {
     @SuppressWarnings("unchecked")
     <T> T walkDocument(byte[] padded, int len, Class<T> expectedType) {
         jsonIterator.init(padded, len);
-        classResolver.reset();
+        // classResolver.reset();
 
         ResolvedClass resolvedExpectedClass = classResolver.resolveClass(expectedType);
         return switch (resolvedExpectedClass.getClassCategory()) {


### PR DESCRIPTION
Every time we parse a document, we enter method `SchemaBasedJsonIterator.walkDocument`. Every time we enter said method, we call `classResolver.reset();`. This clears the class cache and defeats its purpose.

I benchmarked by reading twitter.json into memory, splitting it into 100 individual messages (around ~6kB each), and having each iteration read the 100 messages individually.

We are far slower than Jackson:
```
Benchmark                           Mode   Cnt   Score   Error  Units
SchemaBasedParseBenchmark.jackson     ss  5000   0.700 ± 0.009  ms/op
SchemaBasedParseBenchmark.simdjson    ss  5000  14.051 ± 0.017  ms/op
```

I removed `classResolver.reset()` and benchmarked again:
```
Benchmark                           Mode   Cnt  Score   Error  Units
SchemaBasedParseBenchmark.jackson     ss  5000  0.706 ± 0.008  ms/op
SchemaBasedParseBenchmark.simdjson    ss  5000  0.327 ± 0.006  ms/op
```
We are now faster than Jackson. 

Any reason this `classResolver.reset()` call needs to exist?

Here is my command so you can reproduce my results:
```
java --add-modules=jdk.incubator.vector -jar .\build\libs\simdjson-java-0.4.1-stop-clearing-class-cache-for-each-doc-SNAPSHOT-jmh.jar -wi 200 -i 1000 -tu ms -t 1 SchemaBasedParseBenchmark
```

I also needed to update version of `jsoniterScalaVersion`, or else I would get build errors.